### PR TITLE
Update openssl path for poky branch daisy

### DIFF
--- a/recipes-debian/openssl/openssl_debian.bb
+++ b/recipes-debian/openssl/openssl_debian.bb
@@ -1,4 +1,4 @@
-require recipes-connectivity/openssl/openssl_1.0.1j.bb
+require recipes-connectivity/openssl/openssl_1.0.1m.bb
 FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-connectivity/openssl/openssl:"
 
 inherit debian-package


### PR DESCRIPTION
By following the instructions in the README, the daisy branch of poky that is pulled from Yocto's repository has the required openssl recipe filename of `openssl_1.0.1m.bb` instead of `openssl_1.0.1j.bb`, which meta-debian attempts to find ([link](http://git.yoctoproject.org/clean/cgit.cgi/poky/tree/meta/recipes-connectivity/openssl?h=daisy)).