### PR TITLE
Change order of search path for patches

### DIFF
--- a/recipes-debian/alsa-lib/alsa-lib_debian.bb
+++ b/recipes-debian/alsa-lib/alsa-lib_debian.bb
@@ -1,5 +1,5 @@
 require recipes-multimedia/alsa/${PN}_1.0.27.2.bb
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-multimedia/alsa/alsa-lib:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-multimedia/alsa/alsa-lib:"
 
 inherit debian-package
 DEBIAN_SECTION = "libs"

--- a/recipes-debian/apt/apt-native_debian.bb
+++ b/recipes-debian/apt/apt-native_debian.bb
@@ -1,6 +1,6 @@
 require recipes-devtools/apt/apt-native_0.9.9.4.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-devtools/apt/files:\
+${THISDIR}/files:${COREBASE}/meta/recipes-devtools/apt/files:\
 ${COREBASE}/meta/recipes-devtools/apt/apt-0.9.9.4:\
 "
 

--- a/recipes-debian/base-passwd/base-passwd_debian.bb
+++ b/recipes-debian/base-passwd/base-passwd_debian.bb
@@ -1,6 +1,6 @@
 require recipes-core/base-passwd/base-passwd_3.5.29.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-core/base-passwd/base-passwd:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/base-passwd/base-passwd:\
 "
 
 inherit debian-package

--- a/recipes-debian/binutils/binutils_debian.bb
+++ b/recipes-debian/binutils/binutils_debian.bb
@@ -2,7 +2,7 @@ require recipes-devtools/binutils/binutils.inc
 require recipes-devtools/binutils/binutils-2.24.inc
 
 FILESEXTRAPATHS_prepend ="\
-${COREBASE}/meta/recipes-devtools/binutils/binutils:\
+${THISDIR}/files:${COREBASE}/meta/recipes-devtools/binutils/binutils:\
 "
 
 inherit debian-package

--- a/recipes-debian/bison/bison_debian.bb
+++ b/recipes-debian/bison/bison_debian.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/bison/${PN}_2.7.1.bb
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/bison/bison:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/bison/bison:"
 
 inherit debian-package
 DEBIAN_SECTION = "devel"

--- a/recipes-debian/busybox/busybox_debian.bb
+++ b/recipes-debian/busybox/busybox_debian.bb
@@ -1,7 +1,7 @@
 require recipes-core/busybox/${PN}_1.22.1.bb
 FILESEXTRAPATHS_prepend = "\
 ${THISDIR}/files:\
-${COREBASE}/meta/recipes-core/busybox/files:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/busybox/files:\
 ${COREBASE}/meta/recipes-core/busybox/busybox:\
 "
 

--- a/recipes-debian/busybox/makedevs-native_debian.bb
+++ b/recipes-debian/busybox/makedevs-native_debian.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Tool for creating device nodes"
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-core/busybox/busybox:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/busybox/busybox:\
 ${COREBASE}/meta/recipes-core/busybox/files:\
 "
 

--- a/recipes-debian/e2fsprogs/e2fsprogs_debian.bb
+++ b/recipes-debian/e2fsprogs/e2fsprogs_debian.bb
@@ -1,6 +1,6 @@
 require recipes-devtools/e2fsprogs/${PN}_1.42.9.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-devtools/e2fsprogs/e2fsprogs:\
+${THISDIR}/files:${COREBASE}/meta/recipes-devtools/e2fsprogs/e2fsprogs:\
 "
 
 inherit debian-package

--- a/recipes-debian/elfutils/elfutils_debian.bb
+++ b/recipes-debian/elfutils/elfutils_debian.bb
@@ -1,6 +1,6 @@
 require recipes-devtools/elfutils/${BPN}_0.155.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-devtools/elfutils/elfutils-0.155:\
+${THISDIR}/files:${COREBASE}/meta/recipes-devtools/elfutils/elfutils-0.155:\
 ${COREBASE}/meta/recipes-devtools/elfutils/elfutils:\
 "
 

--- a/recipes-debian/file/file_debian.bb
+++ b/recipes-debian/file/file_debian.bb
@@ -1,5 +1,5 @@
 require file-5.16.inc 
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/file/${BPN}:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/file/${BPN}:"
 
 inherit debian-package
 DEBIAN_SECTION = "utils"

--- a/recipes-debian/gawk/gawk_debian.bb
+++ b/recipes-debian/gawk/gawk_debian.bb
@@ -1,6 +1,6 @@
 require recipes-extended/gawk/gawk_4.0.2.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-extended/gawk/gawk-4.0.2:\
+${THISDIR}/files:${COREBASE}/meta/recipes-extended/gawk/gawk-4.0.2:\
 ${COREBASE}/meta/recipes-extended/gawk/files:\
 "
 

--- a/recipes-debian/gettext/gettext-minimal-native_debian.bb
+++ b/recipes-debian/gettext/gettext-minimal-native_debian.bb
@@ -1,6 +1,6 @@
 require recipes-core/gettext/gettext-minimal-native_0.18.3.2.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-core/gettext/gettext-minimal-0.18.3.2:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/gettext/gettext-minimal-0.18.3.2:\
 "
 
 BPN = "gettext"

--- a/recipes-debian/gettext/gettext_debian.bb
+++ b/recipes-debian/gettext/gettext_debian.bb
@@ -1,6 +1,6 @@
 require recipes-core/gettext/gettext_0.18.3.2.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-core/gettext/gettext-0.18.3.2:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/gettext/gettext-0.18.3.2:\
 "
 
 inherit debian-package

--- a/recipes-debian/glibc/eglibc_debian.bb
+++ b/recipes-debian/glibc/eglibc_debian.bb
@@ -1,5 +1,5 @@
 require recipes-core/eglibc/eglibc_2.19.bb
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-core/eglibc/eglibc-2.19:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-core/eglibc/eglibc-2.19:"
 
 inherit debian-package
 DEBIAN_SECTION = "libs"

--- a/recipes-debian/glibc/ldconfig-native_debian.bb
+++ b/recipes-debian/glibc/ldconfig-native_debian.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "\
 "
 
 FILESPATH_prepend = "\
-${COREBASE}/meta/recipes-core/eglibc/ldconfig-native-2.12.1:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/eglibc/ldconfig-native-2.12.1:\
 ${THISDIR}/files:\
 "
 

--- a/recipes-debian/gmp/gmp_debian.bb
+++ b/recipes-debian/gmp/gmp_debian.bb
@@ -1,6 +1,6 @@
 require recipes-support/gmp/gmp.inc
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-support/gmp/gmp:\
+${THISDIR}/files:${COREBASE}/meta/recipes-support/gmp/gmp:\
 ${COREBASE}/meta/recipes-support/gmp/files:\
 "
 

--- a/recipes-debian/kmod/kmod-native_debian.bb
+++ b/recipes-debian/kmod/kmod-native_debian.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "kmod is a set of tools to handle common tasks with Linux kernel m
 
 HOMEPAGE = "http://packages.profusion.mobi/kmod/"
 
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-kernel/kmod/kmod:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-kernel/kmod/kmod:"
 
 inherit debian-package autotools ptest native debian-test
 DEBIAN_SECTION = "admin"

--- a/recipes-debian/libtool/libtool-cross_debian.bb
+++ b/recipes-debian/libtool/libtool-cross_debian.bb
@@ -1,6 +1,6 @@
 require recipes-devtools/libtool/libtool-cross_2.4.2.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-devtools/libtool/libtool:\
+${THISDIR}/files:${COREBASE}/meta/recipes-devtools/libtool/libtool:\
 "
 
 inherit debian-package

--- a/recipes-debian/libtool/libtool-native_debian.bb
+++ b/recipes-debian/libtool/libtool-native_debian.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/libtool/${PN}_2.4.2.bb
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/libtool/libtool:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/libtool/libtool:"
 
 inherit debian-package
 DEBIAN_SECTION = "devel"

--- a/recipes-debian/libxml/libxml2_debian.bb
+++ b/recipes-debian/libxml/libxml2_debian.bb
@@ -1,6 +1,6 @@
 require recipes-core/libxml/libxml2_2.9.1.bb
 FILESEXTRAPATHS_prepend ="\
-${COREBASE}/meta/recipes-core/libxml/libxml2:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/libxml/libxml2:\
 "
 
 inherit debian-package

--- a/recipes-debian/m4/m4-native_debian.bb
+++ b/recipes-debian/m4/m4-native_debian.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/m4/${PN}_1.4.17.bb
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/m4/m4:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/m4/m4:"
 
 inherit debian-package
 DEBIAN_SECTION = "interpreters"

--- a/recipes-debian/mklibs/mklibs-native_debian.bb
+++ b/recipes-debian/mklibs/mklibs-native_debian.bb
@@ -6,7 +6,7 @@
 # is failed.
 #require recipes-devtools/mklibs/mklibs-native_0.1.38.bb
 
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/mklibs/files:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/mklibs/files:"
 
 DEPENDS = "python-native dpkg-native"
 

--- a/recipes-debian/nspr/nspr_debian.bb
+++ b/recipes-debian/nspr/nspr_debian.bb
@@ -1,6 +1,6 @@
 require recipes-support/nspr/nspr_4.10.3.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-support/nspr/nspr:\
+${THISDIR}/files:${COREBASE}/meta/recipes-support/nspr/nspr:\
 ${COREBASE}/meta/recipes-support/nspr/files:\
 "
 

--- a/recipes-debian/openssl/openssl_debian.bb
+++ b/recipes-debian/openssl/openssl_debian.bb
@@ -1,5 +1,5 @@
 require recipes-connectivity/openssl/openssl_1.0.1m.bb
-FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-connectivity/openssl/openssl"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${THISDIR}/files:${COREBASE}/meta/recipes-connectivity/openssl/openssl"
 
 inherit debian-package
 

--- a/recipes-debian/perl/perl.inc
+++ b/recipes-debian/perl/perl.inc
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/perl/perl-5.14.3:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/perl/perl-5.14.3:"
 
 inherit debian-package
 

--- a/recipes-debian/pkgconfig/pkgconfig_debian.bb
+++ b/recipes-debian/pkgconfig/pkgconfig_debian.bb
@@ -1,6 +1,6 @@
 require recipes-devtools/pkgconfig/pkgconfig_0.28.bb
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-devtools/pkgconfig/pkgconfig-0.28:\
+${THISDIR}/files:${COREBASE}/meta/recipes-devtools/pkgconfig/pkgconfig-0.28:\
 ${COREBASE}/meta/recipes-devtools/pkgconfig/pkgconfig:\
 "
 

--- a/recipes-debian/prelink/prelink_debian.bb
+++ b/recipes-debian/prelink/prelink_debian.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/prelink/prelink_git.bb
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/prelink/prelink:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/prelink/prelink:"
 
 inherit debian-package
 

--- a/recipes-debian/qemu/qemu_debian.bb
+++ b/recipes-debian/qemu/qemu_debian.bb
@@ -1,7 +1,7 @@
 require recipes-devtools/qemu/qemu.inc
 
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-devtools/qemu/qemu:\
+${THISDIR}/files:${COREBASE}/meta/recipes-devtools/qemu/qemu:\
 ${COREBASE}/meta/recipes-devtools/qemu/files:\
 " 
 

--- a/recipes-debian/quilt/quilt-native_debian.bb
+++ b/recipes-debian/quilt/quilt-native_debian.bb
@@ -1,5 +1,5 @@
 require recipes-devtools/quilt/${PN}_0.61.bb
-FILESEXTRAPATHS_prepend = "${COREBASE}/meta/recipes-devtools/quilt/quilt:"
+FILESEXTRAPATHS_prepend = "${THISDIR}/files:${COREBASE}/meta/recipes-devtools/quilt/quilt:"
 
 inherit debian-package
 DEBIAN_SECTION = "vcs"

--- a/recipes-debian/run-postinsts/run-postinsts_1.0.bbappend
+++ b/recipes-debian/run-postinsts/run-postinsts_1.0.bbappend
@@ -1,6 +1,6 @@
 #FILESEXTRAPATHS_prepend = "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta-debian/recipes-debian/run-postinsts/files:\
+${THISDIR}/files:${COREBASE}/meta-debian/recipes-debian/run-postinsts/files:\
 "
 
 # run-postinsts.init from base recipe missing LSB

--- a/recipes-debian/util-linux/util-linux_debian.bb
+++ b/recipes-debian/util-linux/util-linux_debian.bb
@@ -1,7 +1,7 @@
 require recipes-core/util-linux/util-linux_2.24.1.bb
 
 FILESEXTRAPATHS_prepend = "\
-${COREBASE}/meta/recipes-core/util-linux/util-linux:\
+${THISDIR}/files:${COREBASE}/meta/recipes-core/util-linux/util-linux:\
 "
 
 inherit debian-package


### PR DESCRIPTION
Add "${THISDIR}/files:" to FILESEXTRAPATHS_prepend so that
in case files in meta-debian could be choose over files in
meta folder.

Signed-off-by: CongNT <cong.nguyenthe@toshiba-tsdv.com>