### PR TITLE
dpkg-update-alternative: Fix install dir

### DIFF
--- a/recipes-debian/dpkg/files/fix_update_alternatives_dir.patch
+++ b/recipes-debian/dpkg/files/fix_update_alternatives_dir.patch
@@ -17,7 +17,7 @@ index 8a5c902..c1d5a73 100644
 -	-DADMINDIR=\"$(admindir)\" \
 -	-DLOCALEDIR=\"$(localedir)\" \
 +	-DADMINDIR=\"/var/lib/dpkg\" \
-+	-DLOCALEDIR=\"/var/lib/dpkg\" \
++	-DLOCALEDIR=\"/usr/share/locale\" \
  	-DLOGDIR=\"$(logdir)\" \
 -	-DSYSCONFDIR=\"$(sysconfdir)\" \
 +	-DSYSCONFDIR=\"/etc\" \


### PR DESCRIPTION
Correct install path of dpkg-update-alternative.

Signed-off-by: CongNT <cong.nguyenthe@toshiba-tsdv.com>